### PR TITLE
Update mongo.js for MongoDB > 2.6 db.collection.update method

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -56,8 +56,6 @@ module.exports = {
           key: req.prerender.url
         }, object, {
           upsert: true
-        }, function(err) {
-          console.warn(err);
         });
       });
     }


### PR DESCRIPTION
Changed in version 2.6: The update() method returns an object that contains the status of the operation and does not require a callback function to be supplied.
Removed the callback function and all is well.

New install of prerender-mongo threw this error on startup
You have triggered an unhandledRejection, you may have forgotten to catch a Promise rejection:
MongoError: can't find index with key:{ createdAt: 1 }
    at Function.MongoError.create (/opt/prerender/node_modules/mongodb-core/lib/error.js:31:11)
    at /opt/prerender/node_modules/mongodb-core/lib/connection/pool.js:489:72
    at authenticateStragglers (/opt/prerender/node_modules/mongodb-core/lib/connection/pool.js:435:16)
    at null.messageHandler (/opt/prerender/node_modules/mongodb-core/lib/connection/pool.js:469:5)
    at Socket.<anonymous> (/opt/prerender/node_modules/mongodb-core/lib/connection/connection.js:321:22)
    at emitOne (events.js:90:13)
    at Socket.emit (events.js:182:7)
    at readableAddChunk (_stream_readable.js:153:18)
    at Socket.Readable.push (_stream_readable.js:111:10)
    at TCP.onread (net.js:529:20)
It did run however.
It also logged a warn of null every time a record was updated\added.
db.collection update changed in version 2.6: The update() method returns an object that contains the status of the operation.
So I removed the callback function and there are now no startup issues, logged null messages.
lookup and insert functions tested and working